### PR TITLE
ci: only cancel doc CI on `main`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 concurrency:
   group: ${{ github.workflow }}#${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref == 'main' }}
 
 on:
   push:


### PR DESCRIPTION
Currently, the CI to build and deploy the documentation is cancelled by any other run that starts this workflow.

Since it only checks that the docs build on anything other than `main`, we only need it to cancel concurrent runs for `main`. See,
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-on-specific-branches