### PR TITLE
cmake: export into build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,14 @@ install(FILES
   DESTINATION lib/cmake/HighFive
 )
 
+# export targets into build tree
+export(
+    EXPORT HighFiveTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveTargets.cmake"
+    NAMESPACE HighFive::
+)
+
+
 # Preparing local building (tests, examples)
 # ------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,11 @@ write_basic_package_version_file(
   VERSION ${PACKAGE_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HighFiveConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
+    INSTALL_DESTINATION lib/cmake/HighFive
+)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
   DESTINATION "include"
@@ -147,7 +152,7 @@ install(EXPORT HighFiveTargets
 )
 
 install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HighFiveConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfigVersion.cmake
   DESTINATION lib/cmake/HighFive
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ mark_as_advanced(HIGHFIVE_HAS_FRIEND_DECLARATIONS)
 
 option(HIGHFIVE_FIND_HDF5 "Find and link with HDF5." On)
 
-set(HIGHFIVE_CMAKE_INSTALL_DIR "share/HighFive/cmake" CACHE STRING
-  "Directory where HighFive's CMake code will be installed. Default: share/HighFive/cmake")
+set(HIGHFIVE_CMAKE_INSTALL_DIR "lib/cmake/HighFive" CACHE STRING
+  "Directory where HighFive's CMake code will be installed. Default: lib/cmake/HighFive")
 
 
 # Configure Tests & Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
 
 # Install
 # -------
+include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfigVersion.cmake
@@ -137,7 +138,7 @@ write_basic_package_version_file(
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HighFiveConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
-    INSTALL_DESTINATION lib/cmake/HighFive
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
@@ -148,13 +149,13 @@ install(TARGETS HighFive HighFiveInclude EXPORT HighFiveTargets)
 install(EXPORT HighFiveTargets
   FILE HighFiveTargets.cmake
   NAMESPACE HighFive::
-  DESTINATION lib/cmake/HighFive
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
 )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfigVersion.cmake
-  DESTINATION lib/cmake/HighFive
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
 )
 
 # export targets into build tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ mark_as_advanced(HIGHFIVE_HAS_FRIEND_DECLARATIONS)
 
 option(HIGHFIVE_FIND_HDF5 "Find and link with HDF5." On)
 
+set(HIGHFIVE_CMAKE_INSTALL_DIR "share/HighFive/cmake" CACHE STRING
+  "Directory where HighFive's CMake code will be installed. Default: share/HighFive/cmake")
+
+
 # Configure Tests & Examples
 # --------------------------
 
@@ -128,17 +132,17 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
 
 # Install
 # -------
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfigVersion.cmake
   VERSION ${PACKAGE_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
+
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/HighFiveConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
+    INSTALL_DESTINATION ${HIGHFIVE_CMAKE_INSTALL_DIR}
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
@@ -149,13 +153,13 @@ install(TARGETS HighFive HighFiveInclude EXPORT HighFiveTargets)
 install(EXPORT HighFiveTargets
   FILE HighFiveTargets.cmake
   NAMESPACE HighFive::
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
+  DESTINATION ${HIGHFIVE_CMAKE_INSTALL_DIR}
 )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/HighFiveConfigVersion.cmake
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/HighFive/cmake
+  DESTINATION ${HIGHFIVE_CMAKE_INSTALL_DIR}
 )
 
 # export targets into build tree


### PR DESCRIPTION
We are using highfive in a downstream repository, either via cmake's `fetchcontent` or by including it in the build via `add_subdirectory`. Both approaches worked for us with older versions, but with the current `main` we run into several issues. 

With the changes in the PR we have tested the following scenarios, which failed without these changes:

- including `HighFive` in the build of a downstream project, linking against that one - in the build directory; without installation - in yet another downstream project 
- including `HighFive` in the build of a downstream project, installing it into some non-standard location, and then consuming the downstream project in yet another downstream project by using `find_package` with `-Ddownstream_ROOT=...`.