### PR TITLE
xtensor: Make HighFive compatible with 0.26.

### DIFF
--- a/.github/mamba_env_cxx14.yaml
+++ b/.github/mamba_env_cxx14.yaml
@@ -8,5 +8,5 @@ dependencies:
   - eigen
   - graphviz
   - hdf5
-  - xtensor
+  - xtensor<0.26
   - xtl

--- a/.github/mamba_env_cxx17.yaml
+++ b/.github/mamba_env_cxx17.yaml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge
+dependencies:
+  - boost-cpp
+  - catch2
+  - cmake
+  - doxygen
+  - eigen
+  - graphviz
+  - hdf5
+  - xtensor>=0.26
+  - xtl

--- a/.github/mamba_env_cxx20.yaml
+++ b/.github/mamba_env_cxx20.yaml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge
+dependencies:
+  - boost-cpp
+  - catch2
+  - cmake
+  - doxygen
+  - eigen
+  - graphviz
+  - hdf5
+  - xtensor<0.26
+  - xtl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 concurrency:
   group: ${{ github.workflow }}#${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'main' }}
+  cancel-in-progress: ${{ github.ref != 'main' }}
 
 on:
   workflow_dispatch:
@@ -317,11 +317,18 @@ jobs:
 
     - name: Build
       run: |
+        if (( ${{ matrix.cxxstd }} > 14 ))
+        then
+          TEST_XTENSOR=On
+        else
+          TEST_XTENSOR=Off
+        fi
+
         CMAKE_OPTIONS=(
           -GNinja
           -DHIGHFIVE_TEST_BOOST:BOOL=ON
           -DHIGHFIVE_TEST_EIGEN:BOOL=ON
-          -DHIGHFIVE_TEST_XTENSOR:BOOL=ON
+          -DHIGHFIVE_TEST_XTENSOR:BOOL=${TEST_XTENSOR}
           -DHIGHFIVE_BUILD_DOCS:BOOL=FALSE
           -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
         )
@@ -358,18 +365,27 @@ jobs:
 
     - uses: mamba-org/setup-micromamba@v2
       with:
-        environment-file: .github/mamba_env.yaml
+        environment-file: .github/mamba_env_cxx${{matrix.cxxstd}}.yaml
         environment-name: win-test
 
     - name: Build
       shell: bash -l {0}
       run: |
+        if (( ${{ matrix.cxxstd }} == 17 ))
+        then
+          XTENSOR_HEADER_VERSION=2
+        else
+          # Both C++14 and C++20 use 0.26
+          XTENSOR_HEADER_VERSION=1
+        fi
+
         CMAKE_OPTIONS=(
           -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
           -DHIGHFIVE_UNIT_TESTS=ON
           -DHIGHFIVE_TEST_BOOST:BOOL=ON
           -DHIGHFIVE_TEST_EIGEN:BOOL=ON
           -DHIGHFIVE_TEST_XTENSOR:BOOL=ON
+          -DHIGHFIVE_XTENSOR_HEADER_VERSION=$XTENSOR_HEADER_VERSION
         )
         source $GITHUB_WORKSPACE/.github/build.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ option(HIGHFIVE_FIND_HDF5 "Find and link with HDF5." On)
 
 set(HIGHFIVE_CMAKE_INSTALL_DIR "lib/cmake/HighFive" CACHE STRING
   "Directory where HighFive's CMake code will be installed. Default: lib/cmake/HighFive")
-
+set(HIGHFIVE_XTENSOR_HEADER_VERSION "0" CACHE STRING "XTensor header version: 1 for <xtensor/xtensor.hpp>, 2 for <xtensor/containers/xtensor.hpp>, and 0 for automatic detection.")
 
 # Configure Tests & Examples
 # --------------------------

--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ HighFive integrates with the following libraries:
 - xtensor (optional)
 - half (optional)
 
+#### XTensor Header Location
+XTensor reorganized their headers in version 0.26. HighFive attempts to guess
+where the headers can be found. The guessing can be overridded by setting
+`HIGHFIVE_XTENSOR_HEADER_VERSION` to: `1` for finding `xtensor.hpp` in
+`<xtensor/xtensor.hpp>` and `2` for `<xtensor/containers/xtensor.hpp>`.
+
 ## Versioning & Code Stability
 We use semantic versioning. Currently, we're preparing `v3` which contains a
 limited set of breaking changes required to eliminate undesireable behaviour or

--- a/cmake/HighFiveConfig.cmake
+++ b/cmake/HighFiveConfig.cmake
@@ -20,4 +20,9 @@ if(NOT TARGET HighFive)
   add_library(HighFiveInclude ALIAS HighFive::Include)
 endif()
 
+if(HIGHFIVE_XTENSOR_HEADER_VERSION)
+  target_compile_definitions(HighFive::HighFive PUBLIC
+    HIGHFIVE_XTENSOR_HEADER_VERSION=${HIGHFIVE_XTENSOR_HEADER_VERSION}
+  )
+endif()
 

--- a/cmake/HighFiveOptionalDependencies.cmake
+++ b/cmake/HighFiveOptionalDependencies.cmake
@@ -27,6 +27,11 @@ if(NOT TARGET HighFiveXTensorDependency)
     find_package(xtensor REQUIRED)
     target_link_libraries(HighFiveXTensorDependency INTERFACE xtensor)
     target_compile_definitions(HighFiveXTensorDependency INTERFACE HIGHFIVE_TEST_XTENSOR=1)
+
+    if(HIGHFIVE_XTENSOR_HEADER_VERSION)
+      target_compile_definitions(HighFiveXTensorDependency INTERFACE
+        HIGHFIVE_XTENSOR_HEADER_VERSION=${HIGHFIVE_XTENSOR_HEADER_VERSION})
+    endif()
   endif()
 endif()
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -28,8 +28,6 @@
 #endif
 
 #ifdef H5_USE_XTENSOR
-#include <xtensor/xarray.hpp>
-#include <xtensor/xtensor.hpp>
 #include "xtensor.hpp"
 #endif
 

--- a/include/highfive/bits/xtensor_header_version.hpp
+++ b/include/highfive/bits/xtensor_header_version.hpp
@@ -1,0 +1,22 @@
+// clang-format off
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 0
+  #if __cplusplus >= 201703L
+    #if __has_include(<xtensor/xtensor.hpp>)
+      #define HIGHFIVE_XTENSOR_HEADER_VERSION 1
+    #elif __has_include(<xtensor/containers/xtensor.hpp>)
+      #define HIGHFIVE_XTENSOR_HEADER_VERSION 2
+    #else
+      #error "Unable to guess HIGHFIVE_XTENSOR_HEADER_VERSION. Please set manually."
+    #endif
+  #elif __cplusplus == 201402L
+    // XTensor 0.26 and newer require C++17. Hence, if we have C++14, only
+    // `HIGHFIVE_XTENSOR_HEADER_VERSION == 1` makes sense.
+    #define HIGHFIVE_XTENSOR_HEADER_VERSION 1
+  #elif defined(_MSC_VER) && __cplusplus == 199711L
+    #error \
+      "Use /Zc:__cplusplus to make MSVC set __cplusplus correctly or HIGHFIVE_XTENSOR_HEADER_VERSION to skip xtensor version deduction."
+  #else
+    #error "HighFive requires C++14 or newer."
+  #endif
+#endif
+// clang-format on

--- a/include/highfive/xtensor.hpp
+++ b/include/highfive/xtensor.hpp
@@ -2,10 +2,19 @@
 
 #include "bits/H5Inspector_decl.hpp"
 #include "H5Exception.hpp"
+#include "bits/xtensor_header_version.hpp"
 
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xarray.hpp>
 #include <xtensor/xadapt.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/containers/xadapt.hpp>
+#else
+#error "Set HIGHFIVE_XTENSOR_HEADER_VERSION to `1` for pre 0.26; `2` otherwise."
+#endif
 
 namespace HighFive {
 namespace details {

--- a/src/examples/easy_attribute.cpp
+++ b/src/examples/easy_attribute.cpp
@@ -13,7 +13,14 @@
 
 // optionally enable plug-in xtensor
 #ifdef H5_USE_XTENSOR
+#include "bits/xtensor_header_version.hpp"
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xtensor.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/containers/xtensor.hpp>
+#else
+#error "Failed to detect HIGHFIVE_XTENSOR_HEADER_VERSION."
+#endif
 #endif
 
 // optionally enable plug-in Eigen

--- a/src/examples/easy_dumpoptions.cpp
+++ b/src/examples/easy_dumpoptions.cpp
@@ -13,7 +13,14 @@
 
 // optionally enable plug-in xtensor
 #ifdef H5_USE_XTENSOR
+#include <highfive/bits/xtensor_header_version.hpp>
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xtensor.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/containers/xtensor.hpp>
+#else
+#error "Failed to detect HIGHFIVE_XTENSOR_HEADER_VERSION."
+#endif
 #endif
 
 // optionally enable plug-in Eigen

--- a/src/examples/easy_load_dump.cpp
+++ b/src/examples/easy_load_dump.cpp
@@ -13,7 +13,14 @@
 
 // optionally enable plug-in xtensor
 #ifdef H5_USE_XTENSOR
+#include <highfive/bits/xtensor_header_version.hpp>
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xtensor.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/containers/xtensor.hpp>
+#else
+#error "Failed to detect HIGHFIVE_XTENSOR_HEADER_VERSION."
+#endif
 #endif
 
 // optionally enable plug-in Eigen

--- a/tests/unit/test_xtensor.cpp
+++ b/tests/unit/test_xtensor.cpp
@@ -13,10 +13,19 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 #include <highfive/highfive.hpp>
+#include <highfive/xtensor.hpp>
+
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
 #include <xtensor/xio.hpp>
-#include <highfive/xtensor.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/views/xview.hpp>
+#include <xtensor/io/xio.hpp>
+#else
+#error "Failed to detect HIGHFIVE_XTENSOR_HEADER_VERSION."
+#endif
 
 #include "data_generator.hpp"
 

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -22,8 +22,16 @@
 
 
 #ifdef HIGHFIVE_TEST_XTENSOR
+#include <highfive/bits/xtensor_header_version.hpp>
+#if HIGHFIVE_XTENSOR_HEADER_VERSION == 1
 #include <xtensor/xrandom.hpp>
 #include <xtensor/xview.hpp>
+#elif HIGHFIVE_XTENSOR_HEADER_VERSION == 2
+#include <xtensor/generators/xrandom.hpp>
+#include <xtensor/views/xview.hpp>
+#else
+#error "Failed to detect HIGHFIVE_XTENSOR_HEADER_VERSION."
+#endif
 #endif
 
 #ifdef HIGHFIVE_TEST_EIGEN


### PR DESCRIPTION
XTensor reorganized its headers in 0.26. This commit introduces come logic to guess the correct path: if the compiler is C++17 or later, use `__has_include` to check both locations; otherwise it must be an xtensor version prior to 0.26, because 0.26 onwards require a C++17 compiler.

What makes this all a bit more fun is that:
* There's no common header, that would allow us to get an XTensor version number.
* MSVC sets __cplusplus to `199711` regardless of the requested C++ standard.
* Spack doesn't have the new version yet.