### PR TITLE
ci: don't cancel docs build of other PRs.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ permissions:
 
 # Allow only one concurrent deployment
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}#${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
PRs will only build the documentation and never publish it. Therefore, these should run in parallel to check if the docs build and (to save resources) they can cancel previous run when the PR is updated.

The main branch also publishes the docs. Then merging several PRs in short succession the this workflow must be cancelled to avoid outdated docs from being published.