### PR TITLE
ci: replace windows-20{19 -> 25}.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
     runs-on:  ${{matrix.os}}
     strategy:
       matrix:
-        os: [ "windows-2019", "windows-2022"]
+        os: [ "windows-2022", "windows-2025"]
         cxxstd: ["14", "17", "20"]
 
     steps:


### PR DESCRIPTION
The windows-2019 runner is reaching EOL.