### PR TITLE
ci: re-add mpi4py action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       with:
         submodules: true
 
+    - name: "Setup MPI"
+      uses: mpi4py/setup-mpi@v1
+      with:
+        mpi: openmpi
+
     - name: "Install libraries"
       run: |
         sudo apt-get -qq update


### PR DESCRIPTION
Some time after removing the mpi4py/setup-mpi action, we started to see a lot of hard to explain sporadic failures of MPI tests.

This reverts commit 944bc66.