### PR TITLE
cleanup: Improve naming of parameters.

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -69,13 +69,13 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
     ///
     /// \brief File
     /// \param filename: filepath of the HDF5 file
-    /// \param openFlags: Open mode / flags ( ReadOnly, ReadWrite)
+    /// \param access_mode: Open mode / flags ( ReadOnly, ReadWrite, etc.)
     /// \param fileCreateProps: the file create properties
     /// \param fileAccessProps: the file access properties
     ///
     /// Open or create a new HDF5 file
     File(const std::string& filename,
-         AccessMode openFlags,
+         AccessMode access_mode,
          const FileCreateProps& fileCreateProps,
          const FileAccessProps& fileAccessProps = FileAccessProps::Default());
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -130,11 +130,11 @@ class NodeTraits {
     ///
     /// \brief moves an object and its content within an HDF5 file.
     /// \param src_path relative path of the object to current File/Group
-    /// \param dest_path new relative path of the object to current File/Group
+    /// \param dst_path new relative path of the object to current File/Group
     /// \param parents Create intermediate groups if needed. Default: true.
     /// \return boolean that is true if the move was successful
     bool rename(const std::string& src_path,
-                const std::string& dest_path,
+                const std::string& dst_path,
                 bool parents = true) const;
 
     ///
@@ -147,24 +147,24 @@ class NodeTraits {
 
     ///
     /// \brief check a dataset or group exists in the current node / group
-    /// \param node_name dataset/group name to check
+    /// \param node_path dataset/group name to check
     /// \return true if a dataset/group with the associated name exists, or false
-    bool exist(const std::string& node_name) const;
+    bool exist(const std::string& node_path) const;
 
     ///
     /// \brief unlink the given dataset or group
-    /// \param node_name dataset/group name to unlink
-    void unlink(const std::string& node_name) const;
+    /// \param node_path dataset/group name to unlink
+    void unlink(const std::string& node_path) const;
 
     ///
     /// \brief Returns the kind of link of the given name (soft, hard...)
-    /// \param node_name The entry to check, path relative to the current group
-    LinkType getLinkType(const std::string& node_name) const;
+    /// \param node_path The entry to check, path relative to the current group
+    LinkType getLinkType(const std::string& node_path) const;
 
     ///
     /// \brief A shorthand to get the kind of object pointed to (group, dataset, type...)
-    /// \param node_name The entry to check, path relative to the current group
-    ObjectType getObjectType(const std::string& node_name) const;
+    /// \param node_path The entry to check, path relative to the current group
+    ObjectType getObjectType(const std::string& node_path) const;
 
     ///
     /// \brief A shorthand to create softlink to any object which provides `getPath`
@@ -216,7 +216,7 @@ class NodeTraits {
     // A wrapper over the low-level H5Lexist
     // It makes behavior consistent among versions and by default transforms
     // errors to exceptions
-    bool _exist(const std::string& node_name, bool raise_errors = true) const;
+    bool _exist(const std::string& node_path, bool raise_errors = true) const;
 };
 
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -131,8 +131,8 @@ inline PageBufferSize::PageBufferSize(size_t page_buffer_size,
     , _min_meta(min_meta_percent)
     , _min_raw(min_raw_percent) {}
 
-inline PageBufferSize::PageBufferSize(const FileAccessProps& plist) {
-    detail::h5p_get_page_buffer_size(plist.getId(), &_page_buffer_size, &_min_meta, &_min_raw);
+inline PageBufferSize::PageBufferSize(const FileAccessProps& fapl) {
+    detail::h5p_get_page_buffer_size(fapl.getId(), &_page_buffer_size, &_min_meta, &_min_raw);
 }
 
 inline void PageBufferSize::apply(const hid_t list) const {

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -56,7 +56,7 @@ struct BufferInfo {
     const Operation op;
 
     template <class F>
-    BufferInfo(const DataType& dtype, F getName, Operation _op);
+    BufferInfo(const DataType& file_data_type, F getName, Operation _op);
 
     size_t getRank(const T& array) const;
     size_t getMinRank() const;

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -420,23 +420,23 @@ template <typename Derivate>
 class SliceTraits {
   public:
     ///
-    /// \brief Select an \p hyperslab in the current Slice/Dataset.
+    /// \brief Select an \p hyper_slab in the current Slice/Dataset.
     ///
     /// HyperSlabs can be either regular or irregular. Irregular hyperslabs are typically generated
     /// by taking the union of regular hyperslabs. An irregular hyperslab, in general, does not fit
     /// nicely into a multi-dimensional array, but only a subset of such an array.
     ///
     /// Therefore, the only memspaces supported for general hyperslabs are one-dimensional arrays.
-    Selection select(const HyperSlab& hyperslab) const;
+    Selection select(const HyperSlab& hyper_slab) const;
 
     ///
-    /// \brief Select an \p hyperslab in the current Slice/Dataset.
+    /// \brief Select an \p hyper_slab in the current Slice/Dataset.
     ///
     /// If the selection can be read into a simple, multi-dimensional dataspace,
     /// then this overload enable specifying the shape of the memory dataspace
     /// with `memspace`. Note, that simple implies no offsets, strides or
     /// number of blocks, just the size of the block in each dimension.
-    Selection select(const HyperSlab& hyperslab, const DataSpace& memspace) const;
+    Selection select(const HyperSlab& hyper_slab, const DataSpace& memspace) const;
 
     ///
     /// \brief Select a region in the current Slice/Dataset of \p count points at
@@ -492,11 +492,11 @@ class SliceTraits {
     /// responsibility to ensure that the right amount of space has been
     /// allocated.
     /// \param array: A buffer containing enough space for the data
-    /// \param dtype: The type of the data, in case it cannot be automatically guessed
+    /// \param mem_datatype: The type of the data in memory. This prevents deducing it from T.
     /// \param xfer_props: Data Transfer properties
     template <typename T>
     void read_raw(T* array,
-                  const DataType& dtype,
+                  const DataType& mem_datatype,
                   const DataTransferProps& xfer_props = DataTransferProps()) const;
 
     ///

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -214,7 +214,7 @@ inline ProductSet::ProductSet(const Slices&... slices) {
 
 
 template <typename Derivate>
-inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyperslab,
+inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyper_slab,
                                                const DataSpace& memspace) const {
     // Note: The current limitation are that memspace must describe a
     //       packed memspace.
@@ -223,7 +223,7 @@ inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyperslab,
     //       hyperslabs when the memory is not contiguous, e.g.
     //       `std::vector<std::vector<double>>`.
     const auto& slice = static_cast<const Derivate&>(*this);
-    auto filespace = hyperslab.apply(slice.getSpace());
+    auto filespace = hyper_slab.apply(slice.getSpace());
 
     return detail::make_selection(memspace, filespace, details::get_dataset(slice));
 }


### PR DESCRIPTION
The changes include:
  * Consistency between name in decl and defn.
  * `node_name` -> `node_path`.
  * HyperSlab objects are called `hyper_slab`.
  * `openFlags` -> `access_mode`.