### PR TITLE
cleanup: unify code non-RVO return statement.

### DIFF
--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -43,11 +43,7 @@ inline T Reference::dereference(const Object& location) const {
     if (obj.getType() != T::type) {
         HDF5ErrMapper::ToException<ReferenceException>("Trying to dereference the wrong type");
     }
-#if defined __GNUC__ && __GNUC__ < 9
-    return std::move(obj);
-#else
-    return obj;
-#endif
+    return T(std::move(obj));
 }
 
 inline Object Reference::get_ref(const Object& location) const {


### PR DESCRIPTION
Since the type of the object returned doesn't match the return type, implicit conversion is used to create the object. Hence, no RVO is involved and we can unify and make the conversion explicit.