### PR TITLE
cleanup: noexcept code

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -211,8 +211,6 @@ class CompoundType: public DataType {
         size_t offset;
     };
 
-    CompoundType(const CompoundType& other) = default;
-
     ///
     /// \brief Initializes a compound type from a vector of member definitions
     /// \param t_members

--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -25,13 +25,19 @@ class Exception: public std::exception {
     Exception(const std::string& err_msg)
         : _errmsg(err_msg) {}
 
-    ~Exception() throw() override = default;
+    Exception(const Exception& other) = default;
+    Exception(Exception&& other) noexcept = default;
+
+    Exception& operator=(const Exception& other) = default;
+    Exception& operator=(Exception&& other) noexcept = default;
+
+    ~Exception() noexcept override {}
 
     ///
     /// \brief get the current exception error message
     /// \return
     ///
-    inline const char* what() const throw() override {
+    inline const char* what() const noexcept override {
         return _errmsg.c_str();
     }
 

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -79,11 +79,22 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
          const FileCreateProps& fileCreateProps,
          const FileAccessProps& fileAccessProps = FileAccessProps::Default());
 
+    /// \brief Keeps reference count constant, and invalidates other.
+    File(File&& other) noexcept = default;
+
+    /// \brief Keeps reference count constant, and invalidates other.
+    File& operator=(File&& other) = default;
+
+    /// \brief Increments reference count, keeps other valid.
+    File(const File& other) = default;
+
+    /// \brief Increments reference count, keeps other valid.
+    File& operator=(const File& other) = default;
+
     ///
     /// \brief Return the name of the file
     ///
     const std::string& getName() const;
-
 
     /// \brief Object path of a File is always "/"
     std::string getPath() const noexcept {

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -75,13 +75,14 @@ class Object {
     Object(const Object& other);
 
     // Init with an low-level object id
-    explicit Object(hid_t);
+    explicit Object(hid_t) noexcept;
 
     // decrease reference counter
     ~Object();
 
     // Copy-Assignment operator
     Object& operator=(const Object& other);
+    Object& operator=(Object&& other);
 
     hid_t _hid;
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -506,7 +506,7 @@ class Chunking {
 
     explicit Chunking(DataSetCreateProps& plist, size_t max_dims = 32);
 
-    const std::vector<hsize_t>& getDimensions() const noexcept;
+    const std::vector<hsize_t>& getDimensions() const;
 
   private:
     friend DataSetCreateProps;

--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -19,7 +19,7 @@ namespace HighFive {
 inline Object::Object()
     : _hid(H5I_INVALID_HID) {}
 
-inline Object::Object(hid_t hid)
+inline Object::Object(hid_t hid) noexcept
     : _hid(hid) {}
 
 inline Object::Object(const Object& other)
@@ -32,6 +32,17 @@ inline Object::Object(const Object& other)
 inline Object::Object(Object&& other) noexcept
     : _hid(other._hid) {
     other._hid = H5I_INVALID_HID;
+}
+
+inline Object& Object::operator=(Object&& other) {
+    if (this != &other) {
+        if ((*this).isValid()) {
+            detail::h5i_dec_ref(_hid);
+        }
+        _hid = other._hid;
+        other._hid = H5I_INVALID_HID;
+    }
+    return *this;
 }
 
 inline Object& Object::operator=(const Object& other) {

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -296,7 +296,7 @@ inline Chunking::Chunking(DataSetCreateProps& plist, size_t max_dims)
     }
 }
 
-inline const std::vector<hsize_t>& Chunking::getDimensions() const noexcept {
+inline const std::vector<hsize_t>& Chunking::getDimensions() const {
     return _dims;
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,7 +6,7 @@ if(MSVC)
 endif()
 
 ## Base tests
-foreach(test_name tests_high_five_base tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_boost test_empty_arrays test_legacy test_opencv test_string test_stl test_xtensor)
+foreach(test_name tests_high_five_base tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_boost test_empty_arrays test_legacy test_nothrow_movable test_opencv test_string test_stl test_xtensor)
   add_executable(${test_name} "${test_name}.cpp")
   target_link_libraries(${test_name} HighFive HighFiveWarnings HighFiveFlags Catch2::Catch2WithMain)
   target_link_libraries(${test_name} HighFiveOptionalDependencies)

--- a/tests/unit/test_nothrow_movable.cpp
+++ b/tests/unit/test_nothrow_movable.cpp
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c), 2025, HighFive Developers
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <highfive/highfive.hpp>
+
+using namespace HighFive;
+
+template <typename T, bool T1, bool T2, bool T3, bool T4>
+constexpr void check_constructible_assignable() {
+    static_assert(std::is_copy_constructible<T>::value == T1, "Unexpected copy ctor");
+    static_assert(std::is_copy_assignable<T>::value == T2, "Unexpected copy assignment");
+    static_assert(std::is_move_constructible<T>::value == T3, "Unexpected move ctor");
+    static_assert(std::is_move_assignable<T>::value == T4, "Unexpected move assignment");
+}
+
+TEST_CASE("Enshrine constructible/assignable status", "[core]") {
+    // Object isn't constructible at all, because its dtor has
+    // been deleted.
+    check_constructible_assignable<Object, false, false, false, false>();
+    check_constructible_assignable<File, true, true, true, true>();
+    check_constructible_assignable<CompoundType, true, true, true, true>();
+}
+
+template <class T>
+constexpr void check_nothrow_movable() {
+    // Check that if it's moveable, it's nothrow movable.
+    static_assert(std::is_move_constructible<T>::value ==
+                      std::is_nothrow_move_constructible<T>::value,
+                  "For regular classes the move ctor should be noexcept");
+    static_assert(std::is_move_assignable<T>::value == std::is_nothrow_move_assignable<T>::value,
+                  "For regular classes the move assignment should be noexcept");
+}
+
+TEST_CASE("Nothrow movable exceptions", "[core]") {
+    check_nothrow_movable<Exception>();
+    check_nothrow_movable<FileException>();
+    check_nothrow_movable<ObjectException>();
+    check_nothrow_movable<AttributeException>();
+    check_nothrow_movable<DataSpaceException>();
+    check_nothrow_movable<DataSetException>();
+    check_nothrow_movable<GroupException>();
+    check_nothrow_movable<PropertyException>();
+    check_nothrow_movable<ReferenceException>();
+    check_nothrow_movable<DataTypeException>();
+}
+
+template <class T>
+constexpr void check_nothrow_object() {
+    // HighFive objects are reference counted. During move assignment, the
+    // reference count can drop to zero, triggering freeing of the object, which
+    // can fail. Hence, move assignment can file, but move construction shouldn't.
+    static_assert(std::is_move_constructible<T>::value ==
+                      std::is_nothrow_move_constructible<T>::value,
+                  "Move ctor not noexcept");
+    static_assert(!std::is_nothrow_move_assignable<T>::value,
+                  "Move assignment of HighFive::Object can't be noexcept");
+    static_assert(!std::is_nothrow_copy_constructible<T>::value,
+                  "Copy ctor should not be noexcept");
+    static_assert(!std::is_nothrow_copy_assignable<T>::value,
+                  "Copy assignment should not be noexcept");
+}
+
+TEST_CASE("HighFive::Objects are nothrow move constructible", "[core]") {
+    check_nothrow_object<Object>();
+    check_nothrow_object<File>();
+    check_nothrow_object<Attribute>();
+    check_nothrow_object<DataSpace>();
+    check_nothrow_object<DataSet>();
+    check_nothrow_object<Group>();
+    check_nothrow_object<Selection>();
+    check_nothrow_object<DataType>();
+    check_nothrow_object<AtomicType<double>>();
+    check_nothrow_object<CompoundType>();
+    check_nothrow_object<StringType>();
+}
+
+TEST_CASE("Regular HighFive objects are nothrow movable", "[core]") {
+    check_nothrow_movable<RegularHyperSlab>();
+    check_nothrow_movable<HyperSlab>();
+    check_nothrow_movable<ElementSet>();
+    check_nothrow_movable<ProductSet>();
+}


### PR DESCRIPTION
The idea is to have make moving noexcept. The twist is that move assignment requires decrementing a reference count of self (if valid). Which in turn might require freeing the object, which could fail. Hence move assignment is not noexcept for any object that owns an HID. It's still worth implementing since we can steal the reference of `other`.

All other object should behave normally, i.e. both move construction and move assignment are noexcept.

This commit changes two addition occurrences of `noexcept`:

  * Add `noexcept` to `Object(hid_t)`, because it semantically steals the HID and it can't check anything. Moreover, it's useful for move ctors/assignment.

  * Remove `noexcept` from `Chunking::getDimensions` for consistency and freedom to change the implementation later.

Outdated occurrences of `throw()` have been modernized.

There's several occurrences of `noexcept` in successor of `ObjectInfo`. They're not changed, because we probably want to have different objects for different versions of `H5O_info_t` (since that struct dictates what's available).