### PR TITLE
cleanup: explicit ctors.

### DIFF
--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -103,7 +103,7 @@ class DataSet: public Object,
   protected:
     using Object::Object;  // bring DataSet(hid_t)
 
-    DataSet(Object&& o) noexcept
+    explicit DataSet(Object&& o) noexcept
         : Object(std::move(o)) {}
 
     friend class Reference;

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -176,7 +176,7 @@ class VariableLengthStringType: public StringType {
     ///
     /// \brief Create a variable length string HDF5 datatype.
     ///
-    VariableLengthStringType(CharacterSet character_set = CharacterSet::Ascii);
+    explicit VariableLengthStringType(CharacterSet character_set = CharacterSet::Ascii);
 };
 
 
@@ -231,7 +231,7 @@ class CompoundType: public DataType {
     ///
     /// \brief Initializes a compound type from a DataType
     /// \param type
-    inline CompoundType(DataType&& type)
+    inline explicit CompoundType(DataType&& type)
         : DataType(type) {
         if (getClass() != DataTypeClass::Compound) {
             std::ostringstream ss;

--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -22,7 +22,7 @@ namespace HighFive {
 ///
 class Exception: public std::exception {
   public:
-    Exception(const std::string& err_msg)
+    explicit Exception(const std::string& err_msg)
         : _errmsg(err_msg) {}
 
     Exception(const Exception& other) = default;
@@ -87,7 +87,7 @@ class Exception: public std::exception {
 ///
 class ObjectException: public Exception {
   public:
-    ObjectException(const std::string& err_msg)
+    explicit ObjectException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -96,7 +96,7 @@ class ObjectException: public Exception {
 ///
 class DataTypeException: public Exception {
   public:
-    DataTypeException(const std::string& err_msg)
+    explicit DataTypeException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -105,7 +105,7 @@ class DataTypeException: public Exception {
 ///
 class FileException: public Exception {
   public:
-    FileException(const std::string& err_msg)
+    explicit FileException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -114,7 +114,7 @@ class FileException: public Exception {
 ///
 class DataSpaceException: public Exception {
   public:
-    DataSpaceException(const std::string& err_msg)
+    explicit DataSpaceException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -123,7 +123,7 @@ class DataSpaceException: public Exception {
 ///
 class AttributeException: public Exception {
   public:
-    AttributeException(const std::string& err_msg)
+    explicit AttributeException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -132,7 +132,7 @@ class AttributeException: public Exception {
 ///
 class DataSetException: public Exception {
   public:
-    DataSetException(const std::string& err_msg)
+    explicit DataSetException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -141,7 +141,7 @@ class DataSetException: public Exception {
 ///
 class GroupException: public Exception {
   public:
-    GroupException(const std::string& err_msg)
+    explicit GroupException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -150,7 +150,7 @@ class GroupException: public Exception {
 ///
 class PropertyException: public Exception {
   public:
-    PropertyException(const std::string& err_msg)
+    explicit PropertyException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 
@@ -159,7 +159,7 @@ class PropertyException: public Exception {
 ///
 class ReferenceException: public Exception {
   public:
-    ReferenceException(const std::string& err_msg)
+    explicit ReferenceException(const std::string& err_msg)
         : Exception(err_msg) {}
 };
 }  // namespace HighFive

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -56,7 +56,7 @@ class Group: public Object,
         return details::get_plist<GroupCreateProps>(*this, H5Gget_create_plist);
     }
 
-    Group(Object&& o) noexcept
+    explicit Group(Object&& o) noexcept
         : Object(std::move(o)) {};
 
   protected:

--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -23,7 +23,7 @@ namespace HighFive {
 ///
 class SilenceHDF5 {
   public:
-    inline SilenceHDF5(bool enable = true)
+    inline explicit SilenceHDF5(bool enable = true)
         : _client_data(nullptr) {
         detail::nothrow::h5e_get_auto2(H5E_DEFAULT, &_func, &_client_data);
 

--- a/include/highfive/bits/H5Iterables_misc.hpp
+++ b/include/highfive/bits/H5Iterables_misc.hpp
@@ -21,7 +21,7 @@ namespace details {
 // iterator for H5 iterate
 
 struct HighFiveIterateData {
-    inline HighFiveIterateData(std::vector<std::string>& my_names)
+    explicit HighFiveIterateData(std::vector<std::string>& my_names)
         : names(my_names)
         , err(nullptr) {}
 

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -27,12 +27,12 @@ class ElementSet {
     ///
     /// \param list List of continuous coordinates (e.g.: in 2 dimensions space
     /// `ElementSet{1, 2, 3 ,4}` creates points `(1, 2)` and `(3, 4)`).
-    explicit ElementSet(std::initializer_list<std::size_t> list);
+    ElementSet(std::initializer_list<std::size_t> list);
     ///
     /// \brief Create a list of points of N-dimension for selection.
     ///
     /// \param list List of N-dim points.
-    explicit ElementSet(std::initializer_list<std::vector<std::size_t>> list);
+    ElementSet(std::initializer_list<std::vector<std::size_t>> list);
     ///
     /// \brief Create a list of points of N-dimension for selection.
     ///
@@ -63,10 +63,10 @@ inline std::vector<size_t> toSTLSizeVector(const std::vector<hsize_t>& from) {
 struct RegularHyperSlab {
     RegularHyperSlab() = default;
 
-    RegularHyperSlab(const std::vector<size_t>& offset_,
-                     const std::vector<size_t>& count_ = {},
-                     const std::vector<size_t>& stride_ = {},
-                     const std::vector<size_t>& block_ = {})
+    explicit RegularHyperSlab(const std::vector<size_t>& offset_,
+                              const std::vector<size_t>& count_ = {},
+                              const std::vector<size_t>& stride_ = {},
+                              const std::vector<size_t>& block_ = {})
         : offset(toHDF5SizeVector(offset_))
         , count(toHDF5SizeVector(count_))
         , stride(toHDF5SizeVector(stride_))

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -69,7 +69,7 @@ inline ElementSet::ElementSet(const std::vector<std::vector<std::size_t>>& eleme
 namespace detail {
 class HyperCube {
   public:
-    HyperCube(size_t rank)
+    explicit HyperCube(size_t rank)
         : offset(rank)
         , count(rank) {}
 

--- a/tests/unit/tests_high_five_data_type.cpp
+++ b/tests/unit/tests_high_five_data_type.cpp
@@ -395,10 +395,10 @@ TEST_CASE("HighFiveReadType") {
 
     File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-    CompoundType t1 = create_compound_csl1();
+    auto t1 = create_compound_csl1();
     t1.commit(file, datatype_name1);
 
-    CompoundType t2 = file.getDataType(datatype_name1);
+    auto t2 = CompoundType(file.getDataType(datatype_name1));
 
     auto t3 = create_enum_position();
     t3.commit(file, datatype_name2);


### PR DESCRIPTION
Apply clang-tidy fixes for google-explicit-constructor. This prevents implicit conversion and allows passing initializer list to function, to create a temporary argument from the initializer list.