### PR TITLE
remove: concepts for property lists.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
               os: ubuntu-24.04
               pkgs: ''
           - config:
-              os: ubuntu-24.04
+              os: ubuntu-22.04
               pkgs: 'libboost-all-dev libopencv-dev'
               flags: '-DHIGHFIVE_TEST_BOOST:Bool=ON -DHIGHFIVE_TEST_OPENCV:Bool=ON -GNinja'
           - config:
-              os: ubuntu-latest
+              os: ubuntu-24.04
               pkgs: 'libboost-all-dev libeigen3-dev libopencv-dev'
               flags: '-DHIGHFIVE_TEST_BOOST:Bool=ON -DHIGHFIVE_TEST_EIGEN:Bool=ON -DHIGHFIVE_TEST_OPENCV:Bool=ON -GNinja'
           - config:
@@ -58,11 +58,8 @@ jobs:
               pkgs: 'libboost-all-dev'
               flags: '-DCMAKE_CXX_STANDARD=17 -DHIGHFIVE_TEST_BOOST:Bool=ON'
           - config:
-              os: ubuntu-22.04
-              flags: '-DHIGHFIVE_TEST_BOOST=Off -DCMAKE_CXX_STANDARD=20 -DHIGHFIVE_HAS_CONCEPTS=On'
-          - config:
               os: ubuntu-24.04
-              flags: '-DHIGHFIVE_TEST_BOOST=Off -DCMAKE_CXX_STANDARD=20 -DHIGHFIVE_HAS_CONCEPTS=On'
+              flags: '-DHIGHFIVE_TEST_BOOST=Off -DCMAKE_CXX_STANDARD=20'
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,6 @@ option(HIGHFIVE_TEST_OPENCV "Enable testing OpenCV" OFF)
 option(HIGHFIVE_TEST_XTENSOR "Enable testing xtensor" OFF)
 option(HIGHFIVE_TEST_HALF_FLOAT "Enable testing half-precision floats" OFF)
 
-# TODO remove entirely.
-option(HIGHFIVE_HAS_CONCEPTS "Print readable compiler errors w/ C++20 concepts" OFF)
-
 set(HIGHFIVE_MAX_ERRORS 0 CACHE STRING "Maximum number of compiler errors.")
 option(HIGHFIVE_HAS_WERROR "Convert warnings to errors." OFF)
 option(HIGHFIVE_GLIBCXX_ASSERTIONS "Enable bounds check for STL." OFF)

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -131,26 +131,6 @@ class PropertyListBase: public Object {
     friend T details::get_plist(const U&, hid_t (*f)(hid_t));
 };
 
-/// \interface PropertyInterface
-/// \brief HDF5 file property object
-///
-/// A property is an object which is expected to have a method with the
-/// following signature `void apply(hid_t hid) const`
-///
-/// \sa Instructions to document C++20 concepts with Doxygen: https://github.com/doxygen/doxygen/issues/2732#issuecomment-509629967
-///
-/// \cond
-#if HIGHFIVE_HAS_CONCEPTS && __cplusplus >= 202002L
-template <typename P>
-concept PropertyInterface = requires(P p, const hid_t hid) {
-    {p.apply(hid)};
-};
-
-#else
-#define PropertyInterface typename
-#endif
-/// \endcond
-
 ///
 /// \brief HDF5 property Lists
 ///
@@ -167,8 +147,7 @@ class PropertyList: public PropertyListBase {
     /// Add a property to this property list.
     /// A property is an object which is expected to have a method with the
     /// following signature void apply(hid_t hid) const
-    /// \tparam PropertyInterface
-    template <PropertyInterface P>
+    template <typename P>
     void add(const P& property);
 
     ///
@@ -469,7 +448,6 @@ class PageBufferSize {
 #endif
 
 /// \brief Set hints as to how many links to expect and their average length
-/// \implements PropertyInterface
 ///
 class EstimatedLinkInfo {
   public:
@@ -495,7 +473,6 @@ class EstimatedLinkInfo {
 };
 
 
-/// \implements PropertyInterface
 class Chunking {
   public:
     explicit Chunking(const std::vector<hsize_t>& dims);
@@ -514,7 +491,6 @@ class Chunking {
     std::vector<hsize_t> _dims;
 };
 
-/// \implements PropertyInterface
 class Deflate {
   public:
     explicit Deflate(unsigned level);
@@ -526,7 +502,6 @@ class Deflate {
     const unsigned _level;
 };
 
-/// \implements PropertyInterface
 class Szip {
   public:
     explicit Szip(unsigned options_mask = H5_SZIP_EC_OPTION_MASK,
@@ -542,7 +517,6 @@ class Szip {
     const unsigned _pixels_per_block;
 };
 
-/// \implements PropertyInterface
 class Shuffle {
   public:
     Shuffle() = default;
@@ -557,7 +531,6 @@ class Shuffle {
 /// The precise time of when HDF5 requests space to store the dataset
 /// can be configured. Please, consider the upstream documentation for
 /// `H5Pset_alloc_time`.
-/// \implements PropertyInterface
 class AllocationTime {
   public:
     explicit AllocationTime(H5D_alloc_time_t alloc_time);
@@ -574,7 +547,6 @@ class AllocationTime {
 
 /// Dataset access property to control chunk cache configuration.
 /// Do not confuse with the similar file access property for H5Pset_cache
-/// \implements PropertyInterface
 class Caching {
   public:
     /// https://support.hdfgroup.org/HDF5/doc/RM/H5P/H5Pset_chunk_cache.html for
@@ -597,7 +569,6 @@ class Caching {
     double _w0;
 };
 
-/// \implements PropertyInterface
 class CreateIntermediateGroup {
   public:
     explicit CreateIntermediateGroup(bool create = true);
@@ -616,7 +587,6 @@ class CreateIntermediateGroup {
 };
 
 #ifdef H5_HAVE_PARALLEL
-/// \implements PropertyInterface
 class UseCollectiveIO {
   public:
     explicit UseCollectiveIO(bool enable = true);
@@ -639,7 +609,6 @@ class UseCollectiveIO {
 /// creation of this object. This object will not update automatically for later data transfers,
 /// i.e. `H5Pget_mpio_no_collective_cause` is called in the constructor, and not when fetching
 /// a value, such as `wasCollective`.
-/// \implements PropertyInterface
 class MpioNoCollectiveCause {
   public:
     explicit MpioNoCollectiveCause(const DataTransferProps& dxpl);
@@ -675,7 +644,6 @@ struct CreationOrder {
 ///
 /// Let user retrieve objects by creation order time instead of name.
 ///
-/// \implements PropertyInterface
 class LinkCreationOrder {
   public:
     ///
@@ -711,7 +679,6 @@ class LinkCreationOrder {
 /// Please refer to the upstream documentation of `H5Pset_attr_phase_change` or
 /// Section 8 (Attributes) in the User Guide, in particular Subsection 8.5.
 ///
-/// \implements PropertyInterface
 class AttributePhaseChange {
   public:
     ///

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -64,7 +64,7 @@ inline void PropertyList<T>::_initializeIfNeeded() {
 }
 
 template <PropertyType T>
-template <PropertyInterface P>
+template <typename P>
 inline void PropertyList<T>::add(const P& property) {
     _initializeIfNeeded();
     property.apply(_hid);


### PR DESCRIPTION
This commit removes a backwards compatible trick to use concepts for property lists.

It's removed because a) it creates a second "mode" of the library, which adds complexity and requires testing; b) it never got adopted in other parts of HighFive.