### PR TITLE
make AttributePhaseChange available for DataSets and files.

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -696,6 +696,8 @@ class AttributePhaseChange {
     unsigned min_dense() const;
 
   private:
+    friend DataSetCreateProps;
+    friend FileCreateProps;
     friend GroupCreateProps;
     void apply(hid_t hid) const;
 


### PR DESCRIPTION
Since attributes can be added to both groups and datasets, there is no point to make AttributePhaseChange exclusive to GroupCreateProps. Technically, H5Pset_attr_phase_change/H5Pget_attr_phase_change are from [OCPL](https://support.hdfgroup.org/documentation/hdf5/latest/group___o_c_p_l.html), which makes them eligible for ObjectCreateProps, FileCreateProps and DataSetCreateProps. But since ObjectCreateProps is not really used anywhere, only the other two really make sense. Attributes could be added to both DataSets and files (which is the same as adding them to the root group), so the ability to set the phase change for them is also logical.