### PR TITLE
SWMR support

### DIFF
--- a/.github/run_examples.sh
+++ b/.github/run_examples.sh
@@ -15,15 +15,16 @@ fi
 
 for f in "${examples_dir}"/*_bin
 do
-  if [[ "${f}" != *"swmr_"* ]]
+  if [[ "${f}" == *"swmr_"* ]]
+    continue
+  fi
+
+  echo "-- ${f}"
+  if [[ "${f}" == *"parallel_"* ]]
   then
-    echo "-- ${f}"
-    if [[ "${f}" == *"parallel_"* ]]
-    then
-      mpiexec -np 2 "${f}"
-    else
-      "${f}"
-    fi
+    mpiexec -np 2 "${f}"
+  else
+    "${f}"
   fi
 done
 

--- a/.github/run_examples.sh
+++ b/.github/run_examples.sh
@@ -15,11 +15,22 @@ fi
 
 for f in "${examples_dir}"/*_bin
 do
-  echo "-- ${f}"
-  if [[ "${f}" == *"parallel_"* ]]
+  if [[ "${f}" != *"swmr_"* ]]
   then
-    mpiexec -np 2 "${f}"
-  else
-    "${f}"
+    echo "-- ${f}"
+    if [[ "${f}" == *"parallel_"* ]]
+    then
+      mpiexec -np 2 "${f}"
+    else
+      "${f}"
+    fi
   fi
 done
+
+for f in "${examples_dir}"/swmr_*_bin
+do
+  echo "-- ${f}"
+  "${f}" &
+done
+
+wait

--- a/.github/run_examples.sh
+++ b/.github/run_examples.sh
@@ -16,6 +16,7 @@ fi
 for f in "${examples_dir}"/*_bin
 do
   if [[ "${f}" == *"swmr_"* ]]
+  then
     continue
   fi
 

--- a/.github/run_examples.sh
+++ b/.github/run_examples.sh
@@ -31,6 +31,7 @@ done
 
 for f in "${examples_dir}"/swmr_*_bin
 do
+  [ -f "${f}" ] || continue
   echo "-- ${f}"
   "${f}" &
 done

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -129,10 +129,8 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
     void flush();
 
 #if H5_VERSION_GE(1, 10, 0)
-    /// \brief Starts SWMR write
-    ///
-    /// \see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html
-    void startSWMR();
+    /// \brief Switches file to SWMR write mode
+    void startSWMRWrite();
 #endif
 
     /// \brief Get the list of properties for creation of this file

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -40,6 +40,10 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
         Debug = 0x10u,
         /// Open flag: Create non existing file
         Create = 0x20u,
+        /// Open flag: Open in SWMR read
+        ReadSWMR = 0x40u,
+        /// Open flag: Open in SWMR write
+        WriteSWMR = 0x80u,
         /// Derived open flag: common write mode (=ReadWrite|Create|Truncate)
         Overwrite = Truncate,
         /// Derived open flag: Opens RW or exclusively creates
@@ -54,6 +58,8 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
     constexpr static AccessMode Create = AccessMode::Create;
     constexpr static AccessMode Overwrite = AccessMode::Overwrite;
     constexpr static AccessMode OpenOrCreate = AccessMode::OpenOrCreate;
+    constexpr static AccessMode ReadSWMR = AccessMode::ReadSWMR;
+    constexpr static AccessMode WriteSWMR = AccessMode::WriteSWMR;
 
     ///
     /// \brief File
@@ -121,6 +127,13 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
     /// Flushes all buffers associated with a file to disk
     ///
     void flush();
+
+#if H5_VERSION_GE(1, 10, 0)
+    /// \brief Starts SWMR write
+    ///
+    /// \see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html
+    void startSWMR();
+#endif
 
     /// \brief Get the list of properties for creation of this file
     FileCreateProps getCreatePropertyList() const {

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -140,7 +140,7 @@ inline void File::flush() {
 }
 
 #if H5_VERSION_GE(1, 10, 0)
-inline void File::startSWMR() {
+inline void File::startSWMRWrite() {
     detail::h5f_start_swmr_write(_hid);
 }
 #endif

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -41,9 +41,8 @@ inline unsigned convert_open_flag(File::AccessMode openFlags) {
         res_open |= H5F_ACC_SWMR_WRITE | H5F_ACC_RDWR;
 #else
     if (any(openFlags & (File::ReadSWMR | File::WriteSWMR)))
-        throw FileException("Your HDF5 library is too old for SWMR mode: "
-            H5_VERS_STR
-            ", while at least 1.10 is needed.");
+        throw FileException("Your HDF5 library is too old for SWMR mode: " H5_VERS_STR
+                            ", while at least 1.10 is needed.");
 #endif
     return res_open;
 }

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -34,6 +34,17 @@ inline unsigned convert_open_flag(File::AccessMode openFlags) {
         res_open |= H5F_ACC_TRUNC;
     if (any(openFlags & File::Excl))
         res_open |= H5F_ACC_EXCL;
+#if H5_VERSION_GE(1, 10, 0)
+    if (any(openFlags & File::ReadSWMR))
+        res_open |= H5F_ACC_SWMR_READ | H5F_ACC_RDONLY;
+    if (any(openFlags & File::WriteSWMR))
+        res_open |= H5F_ACC_SWMR_WRITE | H5F_ACC_RDWR;
+#else
+    if (any(openFlags & (File::ReadSWMR | File::WriteSWMR)))
+        throw FileException("Your HDF5 library is too old for SWMR mode: "
+            H5_VERS_STR
+            ", while at least 1.10 is needed.");
+#endif
     return res_open;
 }
 }  // namespace
@@ -52,6 +63,9 @@ inline File::File(const std::string& filename,
 
     unsigned createMode = openFlags & (H5F_ACC_TRUNC | H5F_ACC_EXCL);
     unsigned openMode = openFlags & (H5F_ACC_RDWR | H5F_ACC_RDONLY);
+#if H5_VERSION_GE(1, 10, 0)
+    openMode |= openFlags & (H5F_ACC_SWMR_READ | H5F_ACC_SWMR_WRITE);
+#endif
     bool mustCreate = createMode > 0;
     bool openOrCreate = (openFlags & H5F_ACC_CREAT) > 0;
 
@@ -126,6 +140,12 @@ inline hsize_t File::getFileSpacePageSize() const {
 inline void File::flush() {
     detail::h5f_flush(_hid, H5F_SCOPE_GLOBAL);
 }
+
+#if H5_VERSION_GE(1, 10, 0)
+inline void File::startSWMR() {
+    detail::h5f_start_swmr_write(_hid);
+}
+#endif
 
 inline size_t File::getFileSize() const {
     hsize_t sizeValue = 0;

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -41,8 +41,7 @@ inline unsigned convert_open_flag(File::AccessMode openFlags) {
         res_open |= H5F_ACC_SWMR_WRITE | H5F_ACC_RDWR;
 #else
     if (any(openFlags & (File::ReadSWMR | File::WriteSWMR)))
-        throw FileException("Your HDF5 library is too old for SWMR mode: " H5_VERS_STR
-                            ", while at least 1.10 is needed.");
+        throw FileException("Your HDF5 library is too old for SWMR mode, you need at least 1.10");
 #endif
     return res_open;
 }

--- a/include/highfive/bits/h5f_wrapper.hpp
+++ b/include/highfive/bits/h5f_wrapper.hpp
@@ -54,5 +54,16 @@ inline hssize_t h5f_get_freespace(hid_t file_id) {
     return free_space;
 }
 
+#if H5_VERSION_GE(1, 10, 0)
+inline herr_t h5f_start_swmr_write(hid_t file_id) {
+    herr_t err = H5Fstart_swmr_write(file_id);
+    if (err < 0) {
+        HDF5ErrMapper::ToException<FileException>(std::string("Failed to start SWMR write"));
+    }
+
+    return err;
+}
+#endif
+
 }  // namespace detail
 }  // namespace HighFive

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,6 +17,8 @@ set(core_examples
   ${CMAKE_CURRENT_SOURCE_DIR}/renaming_objects.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/select_by_id_dataset_cpp11.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/select_partial_dataset_cpp11.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_read.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_write.cpp
 )
 
 set(span_examples

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -17,8 +17,6 @@ set(core_examples
   ${CMAKE_CURRENT_SOURCE_DIR}/renaming_objects.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/select_by_id_dataset_cpp11.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/select_partial_dataset_cpp11.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_read.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_write.cpp
 )
 
 set(span_examples
@@ -54,6 +52,11 @@ set(parallel_hdf5_examples
 
 set(half_float_examples
   ${CMAKE_CURRENT_SOURCE_DIR}/create_dataset_half_float.cpp
+)
+
+set(swmr_examples
+  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_read.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/swmr_write.cpp
 )
 
 function(compile_example example_source)
@@ -96,6 +99,12 @@ endif()
 
 if(HDF5_IS_PARALLEL)
   foreach(example_source ${parallel_hdf5_examples})
+    compile_example(${example_source})
+  endforeach()
+endif()
+
+if(HDF5_VERSION VERSION_GREATER_EQUAL 1.10.2)
+  foreach(example_source ${swmr_examples})
     compile_example(${example_source})
   endforeach()
 endif()

--- a/src/examples/swmr_read.cpp
+++ b/src/examples/swmr_read.cpp
@@ -18,7 +18,7 @@ const std::string dataset_name("array");
 
 /**
  * This is the SWMR reader.
- * It should be used in conjunction with SWMR writer (see write_swmr example)
+ * It should be used in conjunction with SWMR writer (see swmr_write example)
  */
 int main(void) {
     using namespace HighFive;

--- a/src/examples/swmr_read.cpp
+++ b/src/examples/swmr_read.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c), 2025, George Sedov
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <highfive/highfive.hpp>
+
+const std::string file_name("swmr_read_write.h5");
+const std::string dataset_name("array");
+
+/**
+ * This is the SWMR reader.
+ * It should be used in conjunction with SWMR writer (see write_swmr example)
+ */
+int main(void) {
+    using namespace HighFive;
+
+    // give time for the writer to create the file
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // Open file for SWMR read
+    File file(file_name, File::ReadSWMR);
+
+    std::cout << "Started the SWMR read" << std::endl;
+
+    auto dataset = file.getDataSet(dataset_name);
+    auto dims = dataset.getDimensions();
+    auto olddims = std::vector<size_t>{0ul};
+    while (true) {
+        // refresh is needed for SWMR read
+        dataset.refresh();
+
+        dims = dataset.getDimensions();
+        // if dimensions changed, it means new data was written to a file
+        if (dims[0] != olddims[0]) {
+            std::vector<size_t> slice {dims[0] - olddims[0]};
+            auto values = dataset.select(olddims, slice).read<std::vector<int>>();
+            for (const auto& v : values) {
+                std::cout << v << " ";
+            }
+            std::cout << std::flush;
+            olddims = dims;
+        }
+
+        // there is no way to know that the writer has stopped
+        // we know that our example writer writes exactly 100 values
+        if (dims[0] >= 100) {
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    std::cout << std::endl;
+    return 0;
+}

--- a/src/examples/swmr_read.cpp
+++ b/src/examples/swmr_read.cpp
@@ -41,9 +41,9 @@ int main(void) {
         dims = dataset.getDimensions();
         // if dimensions changed, it means new data was written to a file
         if (dims[0] != olddims[0]) {
-            std::vector<size_t> slice {dims[0] - olddims[0]};
+            std::vector<size_t> slice{dims[0] - olddims[0]};
             auto values = dataset.select(olddims, slice).read<std::vector<int>>();
-            for (const auto& v : values) {
+            for (const auto& v: values) {
                 std::cout << v << " ";
             }
             std::cout << std::flush;

--- a/src/examples/swmr_read.cpp
+++ b/src/examples/swmr_read.cpp
@@ -34,6 +34,9 @@ int main(void) {
     auto dataset = file.getDataSet(dataset_name);
     auto dims = dataset.getDimensions();
     auto olddims = std::vector<size_t>{0ul};
+    size_t max_dim = 10;
+
+    size_t count = 0;
     while (true) {
         // refresh is needed for SWMR read
         dataset.refresh();
@@ -52,11 +55,16 @@ int main(void) {
 
         // there is no way to know that the writer has stopped
         // we know that our example writer writes exactly 100 values
-        if (dims[0] >= 100) {
+        if (dims[0] >= max_dim) {
             break;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (count >= 100 * max_dim) {
+            throw std::runtime_error("SWMR reader timed out.");
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        ++count;
     }
 
     std::cout << std::endl;

--- a/src/examples/swmr_write.cpp
+++ b/src/examples/swmr_write.cpp
@@ -18,7 +18,7 @@ const std::string dataset_name("array");
 
 /**
  * This is the SWMR writer.
- * It should be used in conjunction with SWMR reader (see read_swmr example)
+ * It should be used in conjunction with SWMR reader (see swmr_read example)
  */
 int main(void) {
     using namespace HighFive;

--- a/src/examples/swmr_write.cpp
+++ b/src/examples/swmr_write.cpp
@@ -35,11 +35,12 @@ int main(void) {
     auto dataset =
         file.createDataSet<int>(dataset_name, DataSpace({0ul}, {DataSpace::UNLIMITED}), props);
 
-    // start the SWMR write
+    // Start the SWMR write
     // you are not allowed to create new data headers (i.e. DataSets, Groups, and Attributes) after
-    // that, you should also make sure all the Groups and Attributes are closed before calling this
-    // function see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html for details
-    file.startSWMR();
+    // that, you should also make sure all the Groups and Attributes are closed (i.e. the objects
+    // representing them are out of scope or destroyed) before calling this function
+    // see HDF5 SWMR tutorial for details
+    file.startSWMRWrite();
 
     // If you want to open an already-existing file for SWMR write, use
     // File file(file_name, File::WriteSWMR);

--- a/src/examples/swmr_write.cpp
+++ b/src/examples/swmr_write.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c), 2025, George Sedov
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <highfive/highfive.hpp>
+
+const std::string file_name("swmr_read_write.h5");
+const std::string dataset_name("array");
+
+/**
+ * This is the SWMR writer.
+ * It should be used in conjunction with SWMR reader (see read_swmr example)
+ */
+int main(void) {
+    using namespace HighFive;
+
+    // Create a new file
+    // For SWMR we need to force the latest header, which is passed in AccessProps
+    FileAccessProps fapl;
+    fapl.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
+    File file(file_name, File::Truncate, fapl);
+
+    // To make sense for SWMR, the dataset should be extendable, and hence - chunkable
+    DataSetCreateProps props;
+    props.add(Chunking({1}));
+    auto dataset = file.createDataSet<int>(dataset_name,
+                        DataSpace({0ul}, {DataSpace::UNLIMITED}),
+                        props);
+
+    // start the SWMR write
+    // you are not allowed to create new data headers (i.e. DataSets, Groups, and Attributes) after that
+    // you should also close() or destruct all the Groups and Attributes before calling this function
+    // see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html for details
+    file.startSWMR();
+
+    // If you want to open an already-existing file for SWMR write, use
+    // File file(file_name, File::WriteSWMR);
+    // auto dataset = file.getDataSet(dataset_name);
+
+    std::cout << "Started the SWMR write" << std::endl;
+
+    // Let's write to file.
+    for (int i=0; i<100; i++)
+    {
+        // resize the dataset to fit the new element
+        dataset.resize({static_cast<size_t>(i + 1)});
+        // select the dataset slice and write the number to it
+        dataset.select({static_cast<size_t>(i)}, {1ul}).write(i);
+        // in SWMR mode you need to explicitly flush the DataSet
+        dataset.flush();
+
+        // give time for the reader to react
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    return 0;
+}

--- a/src/examples/swmr_write.cpp
+++ b/src/examples/swmr_write.cpp
@@ -48,7 +48,7 @@ int main(void) {
     std::cout << "Started the SWMR write" << std::endl;
 
     // Let's write to file.
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 10; i++) {
         // resize the dataset to fit the new element
         dataset.resize({static_cast<size_t>(i + 1)});
         // select the dataset slice and write the number to it
@@ -57,7 +57,7 @@ int main(void) {
         dataset.flush();
 
         // give time for the reader to react
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     return 0;

--- a/src/examples/swmr_write.cpp
+++ b/src/examples/swmr_write.cpp
@@ -32,14 +32,13 @@ int main(void) {
     // To make sense for SWMR, the dataset should be extendable, and hence - chunkable
     DataSetCreateProps props;
     props.add(Chunking({1}));
-    auto dataset = file.createDataSet<int>(dataset_name,
-                        DataSpace({0ul}, {DataSpace::UNLIMITED}),
-                        props);
+    auto dataset =
+        file.createDataSet<int>(dataset_name, DataSpace({0ul}, {DataSpace::UNLIMITED}), props);
 
     // start the SWMR write
-    // you are not allowed to create new data headers (i.e. DataSets, Groups, and Attributes) after that
-    // you should also close() or destruct all the Groups and Attributes before calling this function
-    // see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html for details
+    // you are not allowed to create new data headers (i.e. DataSets, Groups, and Attributes) after
+    // that, you should also make sure all the Groups and Attributes are closed before calling this
+    // function see https://docs.hdfgroup.org/archive/support/HDF5/Tutor/swmr.html for details
     file.startSWMR();
 
     // If you want to open an already-existing file for SWMR write, use
@@ -49,8 +48,7 @@ int main(void) {
     std::cout << "Started the SWMR write" << std::endl;
 
     // Let's write to file.
-    for (int i=0; i<100; i++)
-    {
+    for (int i = 0; i < 100; i++) {
         // resize the dataset to fit the new element
         dataset.resize({static_cast<size_t>(i + 1)});
         // select the dataset slice and write the number to it


### PR DESCRIPTION
This is the feature that was introduced in version 1.10 and allows to simultaneously read and write the same file. For this feature to work, you need to call `H5Fstart_swmr_write` on the writer side, and open the file with the flag `H5F_ACC_SWMR_READ` on the reader side. There are also some specific requirements, like all the attributes and groups need to be closed.

The `H5*close` functions are basically glorified destructors. Ultimately they call the same dec_ref as the highfive object destructor calls. But I decided to implement the explicit `close()` function for datasets, groups and attributes, in case user wants to start SWMR write before the relevant objects go out of scope.

Other functions that are needed for SWMR to work are `flush` and `refresh`  for the DataSets which were also added.

I added two new examples to show how SWMR is supposed to work. I didn't add any unit tests, as I'm not sure what exactly needs to be tested.