### PR TITLE
add new functions to dataset

### DIFF
--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -70,6 +70,15 @@ class DataSet: public Object,
     /// \param dims New size of the dataset
     void resize(const std::vector<size_t>& dims);
 
+#if H5_VERSION_GE(1, 10, 0)
+    /// \brief flush
+    void flush();
+#endif
+
+#if H5_VERSION_GE(1, 10, 2)
+    /// \brief refresh
+    void refresh();
+#endif
 
     /// \brief Get the dimensions of the whole DataSet.
     ///       This is a shorthand for getSpace().getDimensions()

--- a/include/highfive/bits/H5DataSet_misc.hpp
+++ b/include/highfive/bits/H5DataSet_misc.hpp
@@ -59,4 +59,16 @@ inline void DataSet::resize(const std::vector<size_t>& dims) {
     detail::h5d_set_extent(getId(), real_dims.data());
 }
 
+#if H5_VERSION_GE(1, 10, 0)
+inline void DataSet::flush() {
+    detail::h5d_flush(_hid);
+}
+#endif
+
+#if H5_VERSION_GE(1, 10, 2)
+inline void DataSet::refresh() {
+    detail::h5d_refresh(_hid);
+}
+#endif
+
 }  // namespace HighFive

--- a/include/highfive/bits/h5d_wrapper.hpp
+++ b/include/highfive/bits/h5d_wrapper.hpp
@@ -74,6 +74,28 @@ inline herr_t h5d_write(hid_t dset_id,
     return err;
 }
 
+#if H5_VERSION_GE(1, 10, 0)
+inline herr_t h5d_flush(hid_t dset_id) {
+    herr_t err = H5Dflush(dset_id);
+    if (err < 0) {
+        HDF5ErrMapper::ToException<DataSetException>("Unable to flush the dataset.");
+    }
+
+    return err;
+}
+#endif
+
+#if H5_VERSION_GE(1, 10, 2)
+inline herr_t h5d_refresh(hid_t dset_id) {
+    herr_t err = H5Drefresh(dset_id);
+    if (err < 0) {
+        HDF5ErrMapper::ToException<DataSetException>("Unable to refresh the dataset.");
+    }
+
+    return err;
+}
+#endif
+
 inline haddr_t h5d_get_offset(hid_t dset_id) {
     uint64_t addr = H5Dget_offset(dset_id);
     if (addr == HADDR_UNDEF) {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1566,6 +1566,9 @@ void readWriteShuffleDeflateTest() {
 
         dataset.write(array);
 
+#if H5_VERSION_GE(1, 10, 0)
+        dataset.flush();
+#endif
         file.flush();
     }
 
@@ -1629,6 +1632,9 @@ void readWriteSzipTest() {
 
         dataset.write(array);
 
+#if H5_VERSION_GE(1, 10, 0)
+        dataset.flush();
+#endif
         file.flush();
     }
 

--- a/tests/unit/tests_high_five_data_type.cpp
+++ b/tests/unit/tests_high_five_data_type.cpp
@@ -101,6 +101,10 @@ TEST_CASE("HighFiveCompounds") {
 
         file.flush();
 
+#if H5_VERSION_GE(1, 10, 2)
+        dataset.refresh();
+#endif
+
         std::vector<CSL1> result;
         dataset.select({0}, {2}).read(result);
 
@@ -120,6 +124,11 @@ TEST_CASE("HighFiveCompounds") {
         dataset.write(csl);
 
         file.flush();
+
+#if H5_VERSION_GE(1, 10, 2)
+        dataset.refresh();
+#endif
+
         std::vector<CSL2> result = {{{1, 1, 1}, {2, 3, 4}}};
         dataset.select({0}, {2}).read(result);
 
@@ -357,6 +366,10 @@ TEST_CASE("HighFiveEnum") {
 
         file.flush();
 
+#if H5_VERSION_GE(1, 10, 2)
+        dataset.refresh();
+#endif
+
         Position result;
         dataset.select(ElementSet({0})).read(result);
 
@@ -376,6 +389,10 @@ TEST_CASE("HighFiveEnum") {
         dataset.write(robot_moves);
 
         file.flush();
+
+#if H5_VERSION_GE(1, 10, 2)
+        dataset.refresh();
+#endif
 
         std::vector<Direction> result;
         dataset.read(result);


### PR DESCRIPTION
This is the split from the SWMR PR. It contains only the DataSet functions that are required for SWMR to function.

SWMR was added in 1.10 but `H5Drefresh` only in 1.10.2. I have no idea how SWMR was supposed to work between those releases. Maybe it didn't. Whatever, the documentation says that it's available from 1.10.2, so here it is.

I added some dummy calls to the functions from the tests, just to keep codecov happy. Both functions have no visible results of their work, so I'm not sure how to test them properly.