### PR TITLE
ci: ignore warnings with on macOS-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,8 +309,16 @@ jobs:
           TEST_XTENSOR=Off
         fi
 
+        if (( ${{ matrix.os }} == "macOS-13" ))
+        then
+          HAS_WERROR=Off
+        else
+          HAS_WERROR=On
+        fi
+
         CMAKE_OPTIONS=(
           -GNinja
+          -DHIGHFIVE_HAS_WERROR:BOOL=${HAS_WERROR}
           -DHIGHFIVE_TEST_BOOST:BOOL=ON
           -DHIGHFIVE_TEST_EIGEN:BOOL=ON
           -DHIGHFIVE_TEST_XTENSOR:BOOL=${TEST_XTENSOR}


### PR DESCRIPTION
The setup with AppleClang 15.0.0 and, e.g., boost 1.89 causes lots of
warnings in dependencies. Since we can't fix published versions of
dependencies, we have to turn off -Werror for this setting.