### PR TITLE
feat: add explicit constructor for DataType class

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -61,6 +61,11 @@ class IntegerType;
 ///
 class DataType: public Object {
   public:
+    explicit DataType(hid_t hid) noexcept :
+        Object(hid)
+    {
+    }
+    
     bool operator==(const DataType& other) const;
 
     bool operator!=(const DataType& other) const;


### PR DESCRIPTION
The purpose is to adapt to H5::ArrayType, like this:
```
struct Grid {
    std::array<double, 3> grid = { 1.0, 2.0, 3.0 };
    static HighFive::CompoundType CompType()
    {
        static constinit hsize_t array_dims[1] = { 3 };
        H5::ArrayType array_type(HDF5Utils::H5_NATIVE_TYPE<double>(), 1, array_dims);

        HighFive::CompoundType result(
            std::vector<HighFive::CompoundType::member_def> {
                { "GRID", HighFive::DataType(array_type.getId()), offsetof(Grid, grid) }
            },
            sizeof(Grid)
        );

        return result;
    }
};
```

If it is because I have misunderstood the implementation of HighFive, please correct me. 
Thank you very much.