### PR TITLE
Add support for setting the locking behavior when opening file

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -206,7 +206,7 @@ is a sensible thing to do. We assume similar about `bool` and
 Anything `H5Easy` related goes in files with the appropriate name.
 
 #### Everything Else
-What's left goes in `tests/unit/test_high_five_base.cpp`. This covers opening
+What's left goes in `tests/unit/tests_high_five_base.cpp`. This covers opening
 files, groups, dataset or attributes; checking certain pathological edge cases;
 etc.
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -714,6 +714,27 @@ class AttributePhaseChange {
     unsigned _min_dense;
 };
 
+///
+/// \brief Set locking FileAccessProps
+///
+/// Since HDF5 in version 1.10.0, `single-writer / multiple-readers` support was added.
+/// To achieve this, locks were added when accessing the file.
+/// They can be disabled with the `HDF5_USE_FILE_LOCKING` environment variable.
+/// However, if it's known at access time that one will never have another process writing the file,
+/// the locks can be avoided.
+///
+/// See more in https://support.hdfgroup.org/documentation/hdf5/latest/_file_lock.html
+///
+class FileLocking {
+  public:
+    explicit FileLocking(bool use_file_locking, bool ignore_when_disabled);
+    void apply(const hid_t list) const;
+  private:
+    friend FileAccessProps;
+    bool _use_file_locking;
+    bool _ignore_when_disabled;
+};
+
 /// @}
 
 }  // namespace HighFive

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -729,6 +729,7 @@ class FileLocking {
   public:
     explicit FileLocking(bool use_file_locking, bool ignore_when_disabled);
     void apply(const hid_t list) const;
+
   private:
     friend FileAccessProps;
     bool _use_file_locking;

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -714,6 +714,7 @@ class AttributePhaseChange {
     unsigned _min_dense;
 };
 
+#if H5_VERSION_GE(1, 10, 0)
 ///
 /// \brief Set locking FileAccessProps
 ///
@@ -735,6 +736,7 @@ class FileLocking {
     bool _use_file_locking;
     bool _ignore_when_disabled;
 };
+#endif
 
 /// @}
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -501,5 +501,12 @@ inline void AttributePhaseChange::apply(hid_t hid) const {
     detail::h5p_set_attr_phase_change(hid, _max_compact, _min_dense);
 }
 
+inline FileLocking::FileLocking(bool use_file_locking, bool ignore_when_disabled)
+    : _use_file_locking(use_file_locking)
+    , _ignore_when_disabled(ignore_when_disabled) { }
+
+inline void FileLocking::apply(hid_t hid) const {
+    detail::h5p_set_file_locking(hid, _use_file_locking, _ignore_when_disabled);
+}
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -503,7 +503,7 @@ inline void AttributePhaseChange::apply(hid_t hid) const {
 
 inline FileLocking::FileLocking(bool use_file_locking, bool ignore_when_disabled)
     : _use_file_locking(use_file_locking)
-    , _ignore_when_disabled(ignore_when_disabled) { }
+    , _ignore_when_disabled(ignore_when_disabled) {}
 
 inline void FileLocking::apply(hid_t hid) const {
     detail::h5p_set_file_locking(hid, _use_file_locking, _ignore_when_disabled);

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -501,6 +501,7 @@ inline void AttributePhaseChange::apply(hid_t hid) const {
     detail::h5p_set_attr_phase_change(hid, _max_compact, _min_dense);
 }
 
+#if H5_VERSION_GE(1, 10, 0)
 inline FileLocking::FileLocking(bool use_file_locking, bool ignore_when_disabled)
     : _use_file_locking(use_file_locking)
     , _ignore_when_disabled(ignore_when_disabled) {}
@@ -508,5 +509,6 @@ inline FileLocking::FileLocking(bool use_file_locking, bool ignore_when_disabled
 inline void FileLocking::apply(hid_t hid) const {
     detail::h5p_set_file_locking(hid, _use_file_locking, _ignore_when_disabled);
 }
+#endif
 
 }  // namespace HighFive

--- a/include/highfive/bits/h5p_wrapper.hpp
+++ b/include/highfive/bits/h5p_wrapper.hpp
@@ -371,6 +371,7 @@ inline herr_t h5p_set_attr_phase_change(hid_t plist_id, unsigned max_compact, un
     return err;
 }
 
+#if H5_VERSION_GE(1, 10, 0)
 inline herr_t h5p_set_file_locking(hid_t plist_id,
                                    bool use_file_locking,
                                    bool ignore_when_disabled) {
@@ -380,6 +381,7 @@ inline herr_t h5p_set_file_locking(hid_t plist_id,
     }
     return err;
 }
+#endif
 
 
 }  // namespace detail

--- a/include/highfive/bits/h5p_wrapper.hpp
+++ b/include/highfive/bits/h5p_wrapper.hpp
@@ -371,6 +371,14 @@ inline herr_t h5p_set_attr_phase_change(hid_t plist_id, unsigned max_compact, un
     return err;
 }
 
+inline herr_t h5p_set_file_locking(hid_t plist_id, bool use_file_locking, bool ignore_when_disabled) {
+    herr_t err = H5Pset_file_locking(plist_id, use_file_locking, ignore_when_disabled);
+    if (err < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Unable to set locking");
+    }
+    return err;
+}
+
 
 }  // namespace detail
 }  // namespace HighFive

--- a/include/highfive/bits/h5p_wrapper.hpp
+++ b/include/highfive/bits/h5p_wrapper.hpp
@@ -371,7 +371,9 @@ inline herr_t h5p_set_attr_phase_change(hid_t plist_id, unsigned max_compact, un
     return err;
 }
 
-inline herr_t h5p_set_file_locking(hid_t plist_id, bool use_file_locking, bool ignore_when_disabled) {
+inline herr_t h5p_set_file_locking(hid_t plist_id,
+                                   bool use_file_locking,
+                                   bool ignore_when_disabled) {
     herr_t err = H5Pset_file_locking(plist_id, use_file_locking, ignore_when_disabled);
     if (err < 0) {
         HDF5ErrMapper::ToException<PropertyException>("Unable to set locking");

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1274,13 +1274,15 @@ TEST_CASE("AttributePhaseChange") {
 }
 
 TEST_CASE("Locking") {
-    auto fapl = HighFive::FileAccessProps::Default();
-    fapl.add(HighFive::FileLocking(true, false));
+    auto fapl0 = HighFive::FileAccessProps::Default();
+    fapl0.add(HighFive::FileLocking(true, false));
     std::string path = "openmodes.h5";
-    HighFive::File file(path, HighFive::File::ReadOnly, fapl);
+    HighFive::File file(path, HighFive::File::ReadOnly, fapl0);
 
     // can't open the same file twice with different locking
-    CHECK_THROWS_AS(HighFive::File(path), FileException);
+    auto fapl1 = HighFive::FileAccessProps::Default();
+    fapl1.add(HighFive::FileLocking(false, false));
+    CHECK_THROWS_AS(HighFive::File(path, HighFive::File::ReadOnly, fapl1), FileException);
 }
 
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1273,6 +1273,17 @@ TEST_CASE("AttributePhaseChange") {
     }
 }
 
+TEST_CASE("Locking") {
+    auto fapl = HighFive::FileAccessProps::Default();
+    fapl.add(HighFive::FileLocking(true, false));
+    std::string path = "openmodes.h5";
+    HighFive::File file(path, HighFive::File::ReadOnly, fapl);
+
+    // can't open the same file twice with different locking
+    CHECK_THROWS_AS(HighFive::File(path), FileException);
+}
+
+
 TEST_CASE("datasetOffset") {
     std::string filename = "datasetOffset.h5";
     std::string dsetname = "dset";

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1273,11 +1273,13 @@ TEST_CASE("AttributePhaseChange") {
     }
 }
 
+#if H5_VERSION_GE(1, 10, 1)
 TEST_CASE("FileAccessProps-FileLocking") {
     auto fapl = HighFive::FileAccessProps::Default();
     fapl.add(HighFive::FileLocking(false, false));
     HighFive::File file("openmodes.h5", HighFive::File::ReadOnly, fapl);
 }
+#endif
 
 
 TEST_CASE("datasetOffset") {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1273,16 +1273,10 @@ TEST_CASE("AttributePhaseChange") {
     }
 }
 
-TEST_CASE("Locking") {
-    auto fapl0 = HighFive::FileAccessProps::Default();
-    fapl0.add(HighFive::FileLocking(true, false));
-    std::string path = "openmodes.h5";
-    HighFive::File file(path, HighFive::File::ReadOnly, fapl0);
-
-    // can't open the same file twice with different locking
-    auto fapl1 = HighFive::FileAccessProps::Default();
-    fapl1.add(HighFive::FileLocking(false, false));
-    CHECK_THROWS_AS(HighFive::File(path, HighFive::File::ReadOnly, fapl1), FileException);
+TEST_CASE("FileAccessProps-FileLocking") {
+    auto fapl = HighFive::FileAccessProps::Default();
+    fapl.add(HighFive::FileLocking(false, false));
+    HighFive::File file("openmodes.h5", HighFive::File::ReadOnly, fapl);
 }
 
 


### PR DESCRIPTION
* useful when on a shared filesystem that limits the number of locks, and files are only being read



With with `fapl.add(HighFive::FileLocking(true, false));` one gets (on linux):
```
ninja && strace tests/unit/tests_high_five_base  FileAccessProps-FileLocking |& grep flock
[0/2] Re-checking globbed directories...
[2/2] Linking CXX executable tests/unit/tests_high_five_base
flock(3, LOCK_SH|LOCK_NB)               = 0
root@fc7be3f8f615:/ws/build-ubuntu24.04#
```

and `fapl.add(HighFive::FileLocking(false, false));`:
```
root@fc7be3f8f615:/ws/build-ubuntu24.04# ninja && strace tests/unit/tests_high_five_base  FileAccessProps-FileLocking |& grep flock
[0/2] Re-checking globbed directories...
[2/2] Linking CXX executable tests/unit/tests_high_five_base
root@fc7be3f8f615:/ws/build-ubuntu24.04#
```
